### PR TITLE
Fix a class name not matching filename

### DIFF
--- a/tests/OfflineClientTest.php
+++ b/tests/OfflineClientTest.php
@@ -10,7 +10,7 @@ use zonuexe\isEvenApi\HttpClient\OfflineHttpClient;
 /**
  * @extends AbstractClientTest<OfflineHttpClient>
  */
-final class OfflineTest extends AbstractClientTest
+final class OfflineClientTest extends AbstractClientTest
 {
     public function getHttpClient(): HttpClient
     {


### PR DESCRIPTION
Test case class not matching filename is deprecated as of PHPUnit 9.1 https://github.com/sebastianbergmann/phpunit/issues/4105